### PR TITLE
Adds CNAME under /docs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+rebloom.io


### PR DESCRIPTION
Required so pushing the gh pages does not clear the custom domain name.