### PR TITLE
Commands.md: Clarify BF.RESERVE's error_rate arg

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -10,22 +10,24 @@ BF.RESERVE {key} {error_rate} {size}
 
 ### Description:
 
-Creates an empty Bloom Filter with a given error ratio and initial capacity.
+Creates an empty Bloom Filter with a given desired error ratio and initial capacity.
 This command is useful if you intend to add many items to a Bloom Filter, 
 otherwise you can just use `BF.ADD` to add items. It will also create a Bloom Filter for
 you if one doesn't already exist.
 
 The initial size and error rate will dictate the performance and memory usage
-of the filter. In general, the higher the error rate (i.e. the lower
+of the filter. In general, the smaller the error rate (i.e. the lower
 the tolerance for false positives) the greater the space consumption per
 filter entry.
 
 ### Parameters:
 
 * **key**: The key under which the filter is to be found
-* **error_rate**: The percentage of expected false positives to be tolerated.
-    The greater this number, the greater the memory consumption per item
-    and the more CPU usage per operation.
+* **error_rate**: The desired probability for false positives. This should
+    be a decimal value between 0 and 1. For example, for a desired false
+    positive rate of 0.1% (1 in 1000), error_rate should be set to 0.001.
+    The closer this number is to zero, the greater the memory consumption per
+    item and the more CPU usage per operation.
 * **size**: The number of entries you intend to add to the filter.
     Performance will begin to degrade after adding more items than this
     number. The actual degradation will depend on how far the limit has


### PR DESCRIPTION
The documentation related to BF.RESERVE's error_rate arg was a bit
misleading and confusing. Specifically, it said that greater values
would result in more space consumption when the opposite is true, and
described it as a "percentage" when it's a ratio, which might result in
people choosing values outside the correct (0, 1) range.