### PR TITLE
Fix RAMP version for installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
     - git clone --depth 1 https://github.com/antirez/redis.git
     - sudo make -C redis install
     - sudo apt-get -qq update
-    - pip install --user redis ramp-packer rmtest
+    - pip install --user redis ramp-packer==1.2.3 rmtest
 
 script:
     - make


### PR DESCRIPTION
The RAMP packaging app has changed its format. Until we fully release clusters with the new format, let's build with the old RAMP format using RAMP 1.2.3